### PR TITLE
COBRA-2990 - In AWS processing indicates that an index or shard has m…

### DIFF
--- a/pkg/broker/instance.go
+++ b/pkg/broker/instance.go
@@ -56,9 +56,9 @@ func IsAvailable(status string) bool {
 }
 
 func InProgress(status string) bool {
-	return status == "upgrading" || status == "creating" || status == "processing"
+	return status == "upgrading" || status == "creating"
 }
 
 func CanGetBindings(status string) bool {
-	return status != "deleted" && status != "creating" && status != "processing"
+	return status != "deleted" && status != "creating"
 }

--- a/pkg/broker/providers-aws-es.go
+++ b/pkg/broker/providers-aws-es.go
@@ -21,7 +21,7 @@ type AWSInstanceESProvider struct {
 }
 
 func IsReady(status *elasticsearchservice.ElasticsearchDomainStatus) bool {
-	return *status.Created == true && *status.Deleted == false && *status.Processing == false && *status.UpgradeProcessing == false
+	return *status.Created == true && *status.Deleted == false && *status.UpgradeProcessing == false
 }
 
 func GetStatus(status *elasticsearchservice.ElasticsearchDomainStatus) string {


### PR DESCRIPTION
…oved on an underlying instance in addition to that a configuraiton change is applying. Some of the index/shard changes can be done via elasticsearch API (e.g., the ES api can affect infrastructure), when this happens the ES instance goes into being unavailalbe, but if the app is responsible for say, readjusting the indexes shard size the ES instance will be in processing state and never return back the config vars since its not ready.  This ignores AWS processing status and considers it available unless its being created, deleted or upgraded.